### PR TITLE
fix: Correct kairos-init version

### DIFF
--- a/images/Dockerfile.alma10
+++ b/images/Dockerfile.alma10
@@ -1,4 +1,4 @@
-FROM quay.io/kairos/kairos-init:v0.6.0@sha256:b326c95650bd4c68422330f414a03e0a7f0f89620194eb30d75f19183016d4ba AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.5.20@sha256:d90e8dd3d43f8c90b4cc9f76b1eb7282823737867dfdf5dda88a66c7683bccfc AS kairos-init
 
 FROM almalinux:10@sha256:a81adef1de0ec017d2f483e6acedf6da4c060a93716192c23cac052386e48035 AS base-kairos
 

--- a/images/Dockerfile.alma9
+++ b/images/Dockerfile.alma9
@@ -1,4 +1,4 @@
-FROM quay.io/kairos/kairos-init:v0.6.0@sha256:b326c95650bd4c68422330f414a03e0a7f0f89620194eb30d75f19183016d4ba AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.5.20@sha256:d90e8dd3d43f8c90b4cc9f76b1eb7282823737867dfdf5dda88a66c7683bccfc AS kairos-init
 
 FROM almalinux:9@sha256:375aa0df1af54a6ad8f4dec9ec3e0df16feec385c4fb761ac5c5ccdd829d0170 AS base-kairos
 


### PR DESCRIPTION
Changes:

Change `kairos-init` version to `0.5.20`. The upgrade to `0.6.0` needed reverting as the Kairo team had mistakenly created a release from a branch that isn't yet ready.